### PR TITLE
Explicitly specify all supported architectures and drop 'sam'.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -51,9 +51,6 @@ jobs:
           - fqbn: arduino:megaavr:nona4809
             platforms: |
               - name: arduino:megaavr
-          - fqbn: arduino:sam:arduino_due_x_dbg
-            platforms: |
-              - name: arduino:sam
           - fqbn: arduino:samd:arduino_zero_edbg
             platforms: |
               - name: arduino:samd

--- a/library.properties
+++ b/library.properties
@@ -6,6 +6,6 @@ sentence=Control DMX lights with your Arduino.
 paragraph=Using RS485 shields, like the MKR 485 Shield. This library depends on the RS485 library.
 category=Other
 url=https://github.com/arduino-libraries/ArduinoDMX
-architectures=*
+architectures=avr,megaavr,samd,mbed_portenta,mbed_nano
 includes=ArduinoDMX.h
 depends=ArduinoRS485


### PR DESCRIPTION
This library uses ArduinoCore-API defined class HardwareSerial which is not fully API compatible with the one used within ArduinoCore-sam. Consequently sam is dropped from the list of supported architectures.

Considering additionally that this library requires Arduino_RS485 which does not support ArduinoCore-sam either.